### PR TITLE
Fix solana

### DIFF
--- a/__tests__/solana/Solana.test.ts
+++ b/__tests__/solana/Solana.test.ts
@@ -56,10 +56,7 @@ describe('Solana Chain Adapter', () => {
   it('should derive address and public key', async () => {
     const { address, publicKey } = await solana.deriveAddressAndPublicKey(
       'predecessor',
-      {
-        index: 0,
-        scheme: 'secp256k1',
-      }
+      'path'
     )
     expect(address).toBeDefined()
     expect(publicKey).toBeDefined()

--- a/package.json
+++ b/package.json
@@ -107,6 +107,5 @@
     "js-sha3": "^0.9.3",
     "near-api-js": "^5.0.1",
     "viem": "^2.22.14"
-  },
-  "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b"
+  }
 }

--- a/src/chain-adapters/Bitcoin/Bitcoin.ts
+++ b/src/chain-adapters/Bitcoin/Bitcoin.ts
@@ -174,7 +174,7 @@ export class Bitcoin extends ChainAdapter<
 
   async deriveAddressAndPublicKey(
     predecessor: string,
-    path: KeyDerivationPath
+    path: string
   ): Promise<{ address: string; publicKey: string }> {
     const uncompressedPubKey = await this.contract.getDerivedPublicKey({
       path,

--- a/src/chain-adapters/Bitcoin/Bitcoin.ts
+++ b/src/chain-adapters/Bitcoin/Bitcoin.ts
@@ -11,7 +11,7 @@ import type {
 import { parseBTCNetwork } from '@chain-adapters/Bitcoin/utils'
 import { ChainAdapter } from '@chain-adapters/ChainAdapter'
 import type { BaseChainSignatureContract } from '@contracts/ChainSignatureContract'
-import type { HashToSign, RSVSignature, KeyDerivationPath } from '@types'
+import type { HashToSign, RSVSignature, UncompressedPubKeySEC1 } from '@types'
 import { cryptography } from '@utils'
 
 /**
@@ -185,7 +185,9 @@ export class Bitcoin extends ChainAdapter<
       throw new Error('Failed to get derived public key')
     }
 
-    const derivedKey = cryptography.compressPubKey(uncompressedPubKey)
+    const derivedKey = cryptography.compressPubKey(
+      uncompressedPubKey as UncompressedPubKeySEC1
+    )
     const publicKeyBuffer = Buffer.from(derivedKey, 'hex')
     const network = parseBTCNetwork(this.network)
 

--- a/src/chain-adapters/ChainAdapter.ts
+++ b/src/chain-adapters/ChainAdapter.ts
@@ -23,7 +23,7 @@ export abstract class ChainAdapter<TransactionRequest, UnsignedTransaction> {
    */
   abstract deriveAddressAndPublicKey(
     predecessor: string,
-    path: KeyDerivationPath
+    path: string
   ): Promise<{
     address: string
     publicKey: string

--- a/src/chain-adapters/ChainAdapter.ts
+++ b/src/chain-adapters/ChainAdapter.ts
@@ -91,5 +91,5 @@ export abstract class ChainAdapter<TransactionRequest, UnsignedTransaction> {
    * @param txSerialized - The serialized signed transaction
    * @returns Promise resolving to an object containing the transaction hash/ID
    */
-  abstract broadcastTx(txSerialized: string): Promise<Hash | { hash: string }>
+  abstract broadcastTx(txSerialized: string): Promise<{ hash: string }>
 }

--- a/src/chain-adapters/ChainAdapter.ts
+++ b/src/chain-adapters/ChainAdapter.ts
@@ -1,4 +1,6 @@
-import type { KeyDerivationPath, HashToSign, RSVSignature } from '@types'
+import { type Transaction } from '@solana/web3.js'
+
+import type { HashToSign, RSVSignature, SolanaSignature } from '@types'
 
 export abstract class ChainAdapter<TransactionRequest, UnsignedTransaction> {
   /**
@@ -78,8 +80,8 @@ export abstract class ChainAdapter<TransactionRequest, UnsignedTransaction> {
    * @returns The serialized signed transaction ready for broadcast
    */
   abstract finalizeTransactionSigning(params: {
-    transaction: UnsignedTransaction
-    rsvSignatures: RSVSignature[]
+    transaction: UnsignedTransaction | Transaction
+    rsvSignatures: RSVSignature[] | SolanaSignature
   }): string
 
   /**

--- a/src/chain-adapters/ChainAdapter.ts
+++ b/src/chain-adapters/ChainAdapter.ts
@@ -1,7 +1,7 @@
 import { type Transaction } from '@solana/web3.js'
 import { type Hash } from 'viem'
 
-import type { HashToSign, RSVSignature, SolanaSignature } from '@types'
+import type { HashToSign, RSVSignature, Signature } from '@types'
 
 export abstract class ChainAdapter<TransactionRequest, UnsignedTransaction> {
   /**
@@ -82,7 +82,7 @@ export abstract class ChainAdapter<TransactionRequest, UnsignedTransaction> {
    */
   abstract finalizeTransactionSigning(params: {
     transaction: UnsignedTransaction | Transaction
-    rsvSignatures: RSVSignature[] | SolanaSignature
+    rsvSignatures: RSVSignature[] | Signature
   }): string
 
   /**

--- a/src/chain-adapters/ChainAdapter.ts
+++ b/src/chain-adapters/ChainAdapter.ts
@@ -1,4 +1,5 @@
 import { type Transaction } from '@solana/web3.js'
+import { type Hash } from 'viem'
 
 import type { HashToSign, RSVSignature, SolanaSignature } from '@types'
 
@@ -90,5 +91,5 @@ export abstract class ChainAdapter<TransactionRequest, UnsignedTransaction> {
    * @param txSerialized - The serialized signed transaction
    * @returns Promise resolving to an object containing the transaction hash/ID
    */
-  abstract broadcastTx(txSerialized: string): Promise<{ hash: string }>
+  abstract broadcastTx(txSerialized: string): Promise<Hash | { hash: string }>
 }

--- a/src/chain-adapters/Cosmos/Cosmos.ts
+++ b/src/chain-adapters/Cosmos/Cosmos.ts
@@ -24,7 +24,7 @@ import type {
 } from '@chain-adapters/Cosmos/types'
 import { fetchChainInfo } from '@chain-adapters/Cosmos/utils'
 import type { BaseChainSignatureContract } from '@contracts/ChainSignatureContract'
-import type { HashToSign, RSVSignature, KeyDerivationPath } from '@types'
+import type { HashToSign, RSVSignature, UncompressedPubKeySEC1 } from '@types'
 import { cryptography } from '@utils'
 
 /**
@@ -131,7 +131,9 @@ export class Cosmos extends ChainAdapter<
       throw new Error('Failed to get derived public key')
     }
 
-    const derivedKey = cryptography.compressPubKey(uncompressedPubKey)
+    const derivedKey = cryptography.compressPubKey(
+      uncompressedPubKey as UncompressedPubKeySEC1
+    )
     const pubKeySha256 = sha256(fromHex(derivedKey))
     const ripemd160Hash = ripemd160(pubKeySha256)
     const address = bech32.encode(prefix, bech32.toWords(ripemd160Hash))

--- a/src/chain-adapters/Cosmos/Cosmos.ts
+++ b/src/chain-adapters/Cosmos/Cosmos.ts
@@ -116,7 +116,7 @@ export class Cosmos extends ChainAdapter<
 
   async deriveAddressAndPublicKey(
     predecessor: string,
-    path: KeyDerivationPath
+    path: string
   ): Promise<{
     address: string
     publicKey: string

--- a/src/chain-adapters/EVM/EVM.ts
+++ b/src/chain-adapters/EVM/EVM.ts
@@ -244,11 +244,11 @@ export class EVM extends ChainAdapter<
                   userOp.paymaster &&
                   isAddress(userOp.paymaster)
                   ? concat([
-                      userOp.paymaster,
-                      pad(userOp.paymasterVerificationGasLimit, { size: 16 }),
-                      pad(userOp.paymasterPostOpGasLimit, { size: 16 }),
-                      userOp.paymasterData,
-                    ])
+                    userOp.paymaster,
+                    pad(userOp.paymasterVerificationGasLimit, { size: 16 }),
+                    pad(userOp.paymasterPostOpGasLimit, { size: 16 }),
+                    userOp.paymasterData,
+                  ])
                   : 'paymasterAndData' in userOp
                     ? userOp.paymasterAndData
                     : '0x'
@@ -320,12 +320,12 @@ export class EVM extends ChainAdapter<
     }
   }
 
-  async broadcastTx(txSerialized: string): Promise<Hash> {
+  async broadcastTx(txSerialized: string): Promise<{ hash: Hash }> {
     try {
       const hash = await this.client.sendRawTransaction({
         serializedTransaction: txSerialized as `0x${string}`,
       })
-      return hash
+      return { hash: hash }
     } catch (error) {
       console.error('Transaction broadcast failed:', error)
       throw new Error('Failed to broadcast transaction.')

--- a/src/chain-adapters/EVM/EVM.ts
+++ b/src/chain-adapters/EVM/EVM.ts
@@ -11,6 +11,7 @@ import {
   numberToHex,
   getAddress,
   type Address,
+  type Hash,
   concatHex,
   encodeAbiParameters,
   hexToBigInt,
@@ -319,12 +320,12 @@ export class EVM extends ChainAdapter<
     }
   }
 
-  async broadcastTx(txSerialized: string): Promise<{ hash: string }> {
+  async broadcastTx(txSerialized: string): Promise<Hash> {
     try {
       const hash = await this.client.sendRawTransaction({
         serializedTransaction: txSerialized as `0x${string}`,
       })
-      return { hash }
+      return hash
     } catch (error) {
       console.error('Transaction broadcast failed:', error)
       throw new Error('Failed to broadcast transaction.')

--- a/src/chain-adapters/EVM/EVM.ts
+++ b/src/chain-adapters/EVM/EVM.ts
@@ -11,7 +11,6 @@ import {
   numberToHex,
   getAddress,
   type Address,
-  type Hash,
   concatHex,
   encodeAbiParameters,
   hexToBigInt,

--- a/src/chain-adapters/EVM/EVM.ts
+++ b/src/chain-adapters/EVM/EVM.ts
@@ -31,7 +31,7 @@ import type {
 } from '@chain-adapters/EVM/types'
 import { fetchEVMFeeProperties } from '@chain-adapters/EVM/utils'
 import type { BaseChainSignatureContract } from '@contracts/ChainSignatureContract'
-import type { HashToSign, RSVSignature, KeyDerivationPath } from '@types'
+import type { HashToSign, RSVSignature } from '@types'
 
 /**
  * Implementation of the ChainAdapter interface for EVM-compatible networks.
@@ -102,7 +102,7 @@ export class EVM extends ChainAdapter<
 
   async deriveAddressAndPublicKey(
     predecessor: string,
-    path: KeyDerivationPath
+    path: string
   ): Promise<{
     address: string
     publicKey: string
@@ -320,11 +320,12 @@ export class EVM extends ChainAdapter<
     }
   }
 
-  async broadcastTx(txSerialized: `0x${string}`): Promise<Hash> {
+  async broadcastTx(txSerialized: string): Promise<{ hash: string }> {
     try {
-      return await this.client.sendRawTransaction({
-        serializedTransaction: txSerialized,
+      const hash = await this.client.sendRawTransaction({
+        serializedTransaction: txSerialized as `0x${string}`,
       })
+      return { hash }
     } catch (error) {
       console.error('Transaction broadcast failed:', error)
       throw new Error('Failed to broadcast transaction.')

--- a/src/chain-adapters/Solana/Solana.ts
+++ b/src/chain-adapters/Solana/Solana.ts
@@ -3,7 +3,7 @@ import { PublicKey, Transaction, SystemProgram } from '@solana/web3.js'
 import type BN from 'bn.js'
 
 import type { BaseChainSignatureContract } from '@contracts/ChainSignatureContract'
-import type { HashToSign, SolanaSignature } from '@types'
+import type { HashToSign, Signature } from '@types'
 
 import { ChainAdapter } from '../ChainAdapter'
 
@@ -134,7 +134,7 @@ export class Solana extends ChainAdapter<
     senderAddress,
   }: {
     transaction: Transaction
-    rsvSignatures: SolanaSignature
+    rsvSignatures: Signature
     senderAddress: string
   }): string {
     const signatureBuffer = Buffer.from(rsvSignatures.signature)

--- a/src/chain-adapters/Solana/Solana.ts
+++ b/src/chain-adapters/Solana/Solana.ts
@@ -1,10 +1,9 @@
-import { fromHex } from '@cosmjs/encoding'
 import type { Connection } from '@solana/web3.js'
 import { PublicKey, Transaction, SystemProgram } from '@solana/web3.js'
 import type BN from 'bn.js'
 
 import type { BaseChainSignatureContract } from '@contracts/ChainSignatureContract'
-import type { KeyDerivationPath, HashToSign, RSVSignature } from '@types'
+import type { HashToSign, SolanaSignature } from '@types'
 
 import { ChainAdapter } from '../ChainAdapter'
 
@@ -52,14 +51,15 @@ export class Solana extends ChainAdapter<
     const pubKey = await this.contract.getDerivedPublicKey({
       path,
       predecessor,
+      IsEd25519: true,
     })
-    // Convert the public key to Solana format (base58)
-    // Note: Need to implement conversion from contract's public key format to Solana's
-    const solanaPublicKey = new PublicKey(pubKey)
+
+    const base58Key = pubKey.replace('ed25519:', '')
+    const publicKey = new PublicKey(base58Key)
 
     return {
-      address: solanaPublicKey.toBase58(),
-      publicKey: pubKey,
+      address: publicKey.toBase58(),
+      publicKey: publicKey.toString(),
     }
   }
 
@@ -128,8 +128,18 @@ export class Solana extends ChainAdapter<
     }
   }
 
-  finalizeTransactionSigning({ transaction, rsvSignatures }: { transaction: SolanaUnsignedTransaction; rsvSignatures: { r: string; s: string; v: number }[] }): string {
-    throw new Error('Not implemented');
+  finalizeTransactionSigning({
+    transaction,
+    rsvSignatures,
+    senderAddress,
+  }: {
+    transaction: Transaction
+    rsvSignatures: SolanaSignature
+    senderAddress: string
+  }): string {
+    const signatureBuffer = Buffer.from(rsvSignatures.signature)
+    transaction.addSignature(new PublicKey(senderAddress), signatureBuffer)
+    return transaction.serialize().toString('base64')
   }
 
   async broadcastTx(txSerialized: string): Promise<{ hash: string }> {
@@ -140,16 +150,5 @@ export class Solana extends ChainAdapter<
     )
 
     return { hash: signature }
-  }
-
-  private convertRSVToSolanaSignature(rsvSignature: RSVSignature): Uint8Array {
-    const r = fromHex(rsvSignature.r)
-    const s = fromHex(rsvSignature.s)
-
-    const solanaSignature = new Uint8Array(64)
-    solanaSignature.set(r, 0)
-    solanaSignature.set(s, 32)
-
-    return solanaSignature
   }
 }

--- a/src/chain-adapters/Solana/Solana.ts
+++ b/src/chain-adapters/Solana/Solana.ts
@@ -1,4 +1,4 @@
-import type { Connection } from '@solana/web3.js'
+import type { Connection as SolanaConnection } from '@solana/web3.js'
 import { PublicKey, Transaction, SystemProgram } from '@solana/web3.js'
 import type BN from 'bn.js'
 
@@ -21,15 +21,15 @@ export class Solana extends ChainAdapter<
   SolanaTransactionRequest,
   SolanaUnsignedTransaction
 > {
-  private readonly connection: Connection
+  private readonly connection: SolanaConnection
   private readonly contract: BaseChainSignatureContract
 
   constructor(args: {
-    connection: Connection
+    solanaConnection: SolanaConnection
     contract: BaseChainSignatureContract
   }) {
     super()
-    this.connection = args.connection
+    this.connection = args.solanaConnection
     this.contract = args.contract
   }
 

--- a/src/chain-adapters/Solana/Solana.ts
+++ b/src/chain-adapters/Solana/Solana.ts
@@ -47,7 +47,7 @@ export class Solana extends ChainAdapter<
 
   async deriveAddressAndPublicKey(
     predecessor: string,
-    path: KeyDerivationPath
+    path: string
   ): Promise<{ address: string; publicKey: string }> {
     const pubKey = await this.contract.getDerivedPublicKey({
       path,

--- a/src/contracts/ChainSignatureContract.ts
+++ b/src/contracts/ChainSignatureContract.ts
@@ -39,7 +39,7 @@ export abstract class BaseChainSignatureContract {
    */
   abstract getDerivedPublicKey(
     args: {
-      path: KeyDerivationPath
+      path: string
       predecessor: string
     } & Record<string, unknown>
   ): Promise<UncompressedPubKeySEC1>

--- a/src/contracts/ChainSignatureContract.ts
+++ b/src/contracts/ChainSignatureContract.ts
@@ -3,8 +3,13 @@ import type BN from 'bn.js'
 import type {
   RSVSignature,
   UncompressedPubKeySEC1,
-  KeyDerivationPath,
+  Ed25519PubKey,
+  DerivedPublicKeyArgs,
 } from '../types'
+
+export interface ArgsEd25519 extends DerivedPublicKeyArgs {
+  IsEd25519: boolean
+}
 
 export interface SignArgs {
   /** The payload to sign as an array of 32 bytes */
@@ -35,14 +40,13 @@ export abstract class BaseChainSignatureContract {
    * @param args - Arguments for key derivation
    * @param args.path - The path to use derive the key
    * @param args.predecessor - The id/address of the account requesting signature
+   * @param args.IsEd25519 - Flag indicating if the key is Ed25519
    * @returns Promise resolving to the derived SEC1 uncompressed public key
    */
+  // abstract getDerivedPublicKey(args: ArgsEd25519): Promise<Ed25519PubKey>
   abstract getDerivedPublicKey(
-    args: {
-      path: string
-      predecessor: string
-    } & Record<string, unknown>
-  ): Promise<UncompressedPubKeySEC1>
+    args: DerivedPublicKeyArgs | ArgsEd25519
+  ): Promise<UncompressedPubKeySEC1 | Ed25519PubKey>
 }
 
 /**

--- a/src/contracts/evm/ChainSignaturesContract.ts
+++ b/src/contracts/evm/ChainSignaturesContract.ts
@@ -89,6 +89,9 @@ export class ChainSignatureContract extends AbstractChainSignatureContract {
     path: string
     predecessor: string
   }): Promise<UncompressedPubKeySEC1> {
+    if ('IsEd25519' in args && args.IsEd25519) {
+      throw new Error('Ed25519 not supported on EVM chains')
+    }
     const pubKey = cryptography.deriveChildPublicKey(
       await this.getPublicKey(),
       args.predecessor.toLowerCase(),

--- a/src/contracts/near/signAndSend/keypair.ts
+++ b/src/contracts/near/signAndSend/keypair.ts
@@ -54,7 +54,7 @@ export const EVMTransaction = async (
     const txHash = await evm.broadcastTx(txSerialized)
 
     return {
-      transactionHash: txHash,
+      transactionHash: txHash.hash,
       success: true,
     }
   } catch (e: unknown) {

--- a/src/contracts/near/signAndSend/keypair.ts
+++ b/src/contracts/near/signAndSend/keypair.ts
@@ -54,7 +54,7 @@ export const EVMTransaction = async (
     const txHash = await evm.broadcastTx(txSerialized)
 
     return {
-      transactionHash: txHash,
+      transactionHash: txHash.hash,
       success: true,
     }
   } catch (e: unknown) {
@@ -112,7 +112,7 @@ export const BTCTransaction = async (
     const txHash = await btc.broadcastTx(txSerialized)
 
     return {
-      transactionHash: txHash,
+      transactionHash: txHash.hash,
       success: true,
     }
   } catch (e: unknown) {

--- a/src/contracts/near/signAndSend/keypair.ts
+++ b/src/contracts/near/signAndSend/keypair.ts
@@ -54,7 +54,7 @@ export const EVMTransaction = async (
     const txHash = await evm.broadcastTx(txSerialized)
 
     return {
-      transactionHash: txHash.hash,
+      transactionHash: txHash,
       success: true,
     }
   } catch (e: unknown) {

--- a/src/contracts/near/types.ts
+++ b/src/contracts/near/types.ts
@@ -42,7 +42,7 @@ export interface EVMRequest {
   chainConfig: EVMChainConfigWithProviders
   nearAuthentication: NearAuthentication
   fastAuthRelayerUrl?: string
-  derivationPath: KeyDerivationPath
+  derivationPath: string
 }
 
 export type BTCChainConfigWithProviders = ChainProvider & {
@@ -54,7 +54,7 @@ export interface BitcoinRequest {
   chainConfig: BTCChainConfigWithProviders
   nearAuthentication: NearAuthentication
   fastAuthRelayerUrl?: string
-  derivationPath: KeyDerivationPath
+  derivationPath: string
 }
 
 export interface CosmosChainConfig {
@@ -66,6 +66,6 @@ export interface CosmosRequest {
   chainConfig: CosmosChainConfig
   transaction: CosmosTransactionRequest
   nearAuthentication: NearAuthentication
-  derivationPath: KeyDerivationPath
+  derivationPath: string
   fastAuthRelayerUrl?: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface DerivedPublicKeyArgs {
   predecessor: string
 }
 
-export interface SolanaSignature {
+export interface Signature {
   scheme: string
   signature: number[]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,18 @@ export type UncompressedPubKeySEC1 = `04${string}`
 
 export type CompressedPubKeySEC1 = `02${string}` | `03${string}`
 
+export type Ed25519PubKey = `Ed25519:${string}`
+
+export interface DerivedPublicKeyArgs {
+  path: string
+  predecessor: string
+}
+
+export interface SolanaSignature {
+  scheme: string
+  signature: number[]
+}
+
 export interface KeyDerivationPath {
   index: number
   scheme: 'secp256k1' | 'ed25519'


### PR DESCRIPTION
## Solana Integration Update

I updated the methods and types for the Solana integration.

There were issues with **pnpm**, tests, and type definitions, so I switched to **yarn** and **yalc** for testing purposes.  
I also fixed several type-related problems.  
Manual testing for Bitcoin and EVM examples is pending.

---

### How to Test the Solana Example

You only need to use **yalc** to test the Solana example.

#### Steps:

1. Checkout to the `fixSolana` branch:
    ```bash
    git checkout fixSolana
    ```

2. Build and publish the package locally:
    ```bash
    yarn build
    cd dist
    yalc publish
    ```

3. Clone the example repository:
    [https://github.com/matiasbenary/near-multichain/tree/addSolanaExample](https://github.com/matiasbenary/near-multichain/tree/addSolanaExample)

4. Inside the example project, run:
    ```bash
    yalc add chainsig.js@1.0.35
    yarn
    yarn run dev
    ```

---

Let me know if you find any issues!