### PR TITLE
feat: add sign authorization utility into evm adapter

### DIFF
--- a/src/chain-adapters/EVM/types.ts
+++ b/src/chain-adapters/EVM/types.ts
@@ -5,6 +5,7 @@ import type {
   TypedDataDefinition,
   SignableMessage,
 } from 'viem'
+import { HashAuthorizationParameters } from 'viem/experimental'
 
 export type EVMUnsignedTransaction = TransactionRequest & {
   type: 'eip1559'
@@ -15,6 +16,8 @@ export interface EVMTransactionRequest
   extends Omit<EVMUnsignedTransaction, 'chainId' | 'type'> {
   from: Address
 }
+
+export type EVMAuthorizationRequest = HashAuthorizationParameters<"hex">
 
 export type EVMMessage = SignableMessage
 


### PR DESCRIPTION
This adds two methods in EVM class.
- prepareAuthorizationForSigning
- finalizeAuthorizationSigning

This is added for EIP 7702.

Note: Some methods are importing from `viem/experimental`. We could change it to `viem` after upgrading `viem` package. But I'm not sure if we should sqeeze the `viem` update in this PR as well.