### PR TITLE
feat(evm): add legacy transaction signing for Theta support

### DIFF
--- a/src/chain-adapters/EVM/types.ts
+++ b/src/chain-adapters/EVM/types.ts
@@ -17,6 +17,25 @@ export interface EVMTransactionRequest
   from: Address
 }
 
+// Legacy transaction request coming from your dApp (includes 'from' address)
+export interface EVMTransactionRequestLegacy {
+  from: `0x${string}`
+  to: `0x${string}`
+  value?: bigint
+  gas?: bigint
+}
+
+// Legacy unsigned transaction to be signed
+export type EVMUnsignedLegacyTransaction = {
+  to: `0x${string}`
+  value?: bigint
+  gasPrice: bigint
+  nonce: number
+  gas: bigint
+  chainId: number
+  type: 'legacy'
+}
+
 export type EVMAuthorizationRequest = HashAuthorizationParameters<"hex">
 
 export type EVMMessage = SignableMessage


### PR DESCRIPTION
### ✨ Feature: Legacy Transaction Support for Theta Network

This PR adds support for `legacy` (type 0) Ethereum transactions to enable compatibility with Theta EVM.

New methods added:
- `prepareTransactionForSigningLegacy`
- `attachGasAndNonceLegacy`
- `finalizeTransactionSigningLegacy`

These avoid EIP-1559 fields and serialize using legacy rules.

Tested locally with Theta Testnet ✅