### PR TITLE
fix: examples

### DIFF
--- a/examples/send-btc.ts
+++ b/examples/send-btc.ts
@@ -4,6 +4,7 @@ import { connect } from 'near-api-js'
 import { getTransactionLastResult } from '@near-js/utils'
 import { Action } from '@near-js/transactions'
 import { contracts, chainAdapters } from 'chainsig.js'
+import { createAction } from '@near-wallet-selector/wallet-utils'
 
 import dotenv from 'dotenv'
 import { KeyPairString } from '@near-js/crypto'
@@ -84,7 +85,7 @@ async function main() {
         const transactions = walletSelectorTransactions.map((tx) => {
           return {
             receiverId: tx.receiverId,
-            actions: tx.actions,
+            actions: tx.actions.map((a) => createAction(a)),
           } satisfies { receiverId: string; actions: Action[] }
         })
 

--- a/examples/send-eth.ts
+++ b/examples/send-eth.ts
@@ -6,7 +6,7 @@ import { Action } from '@near-js/transactions'
 import { contracts, chainAdapters } from 'chainsig.js'
 import { createPublicClient, http } from 'viem'
 import { sepolia } from 'viem/chains'
-
+import { createAction } from '@near-wallet-selector/wallet-utils'
 
 import dotenv from 'dotenv'
 import { KeyPairString } from '@near-js/crypto'
@@ -87,7 +87,7 @@ async function main() {
         const transactions = walletSelectorTransactions.map((tx) => {
           return {
             receiverId: tx.receiverId,
-            actions: tx.actions,
+            actions: tx.actions.map((a) => createAction(a)),
           } satisfies { receiverId: string; actions: Action[] }
         })
 

--- a/examples/send-sol.ts
+++ b/examples/send-sol.ts
@@ -6,6 +6,7 @@ import { Action } from '@near-js/transactions'
 import { contracts, chainAdapters } from 'chainsig.js'
 import { createPublicClient, http } from 'viem'
 import { sepolia } from 'viem/chains'
+import { createAction } from '@near-wallet-selector/wallet-utils'
 
 
 import { Connection as SolanaConnection } from '@solana/web3.js'
@@ -85,7 +86,7 @@ async function main() {
         const transactions = walletSelectorTransactions.map((tx) => {
           return {
             receiverId: tx.receiverId,
-            actions: tx.actions,
+            actions: tx.actions.map((a) => createAction(a)),
           } satisfies { receiverId: string; actions: Action[] }
         })
 

--- a/examples/send-sui.ts
+++ b/examples/send-sui.ts
@@ -83,11 +83,9 @@ const signature = await contract.sign({
       const results = []
       
       for (const tx of walletSelectorTransactions) {
-        const actions = tx.actions
-        
         const result = await account.signAndSendTransaction({
           receiverId: tx.receiverId,
-          actions,
+          actions: tx.actions,
         })
         
         // @ts-ignore - Type mismatch between @near-js package versions

--- a/examples/send-xrp.ts
+++ b/examples/send-xrp.ts
@@ -4,6 +4,7 @@ import { connect } from 'near-api-js'
 import { getTransactionLastResult } from '@near-js/utils'
 import { Action } from '@near-js/transactions'
 import { contracts, chainAdapters } from 'chainsig.js'
+import { createAction } from '@near-wallet-selector/wallet-utils'
 
 
 import dotenv from 'dotenv'
@@ -86,7 +87,7 @@ async function main() {
         const transactions = walletSelectorTransactions.map((tx) => {
           return {
             receiverId: tx.receiverId,
-            actions: tx.actions,
+            actions: tx.actions.map((a) => createAction(a)),
           } satisfies { receiverId: string; actions: Action[] }
         })
 


### PR DESCRIPTION
Hey, we noticed that the current examples don’t run as-is with chainsig.js unless the action is wrapped inside createAction. Ideally, libraries should be interoperable without this extra step. We’re adding this PR to make the examples work smoothly out of the box, so others can have an easier experience running them.